### PR TITLE
Race Condition - Listener Callback

### DIFF
--- a/lib/src/main/java/net/ypresto/androidtranscoder/MediaTranscoder.java
+++ b/lib/src/main/java/net/ypresto/androidtranscoder/MediaTranscoder.java
@@ -123,20 +123,20 @@ public class MediaTranscoder {
 
             @Override
             public void onTranscodeCompleted() {
-                listener.onTranscodeCompleted();
                 closeStream();
+                listener.onTranscodeCompleted();
             }
 
             @Override
             public void onTranscodeCanceled() {
-                listener.onTranscodeCanceled();
                 closeStream();
+                listener.onTranscodeCanceled();
             }
 
             @Override
             public void onTranscodeFailed(Exception exception) {
-                listener.onTranscodeFailed(exception);
                 closeStream();
+                listener.onTranscodeFailed(exception);
             }
 
             private void closeStream() {


### PR DESCRIPTION
A race condition can occur on a Samsung Galaxy 2 Camera resulting in a timeout if you attempt to upload a recorded video using the cordova-plugin-file-transfer plugin inside the onTransferComplete callback.

The solution is to close the output file stream before raising the callback function.
